### PR TITLE
Add offline.php and 500.php templates

### DIFF
--- a/500.php
+++ b/500.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * The template for displaying 500 pages (internal server errors)
+ *
+ * @link https://github.com/xwp/pwa-wp
+ *
+ * @package Twenty_Seventeen_Westonson
+ */
+
+get_header(); ?>
+
+<div class="wrap">
+	<div id="primary" class="content-area">
+		<main id="main" class="site-main" role="main">
+
+			<section class="error-500 internal-server-error">
+				<header class="page-header">
+					<h1 class="page-title"><?php esc_html_e( 'Oops! Something went wrong.', 'twentyseventeen-westonson' ); ?></h1>
+				</header><!-- .page-header -->
+				<div class="page-content">
+					<p><?php esc_html_e( 'Something prevented the page from being rendered. Please try again.', 'twentyseventeen-westonson' ); ?></p>
+					<details id="error-details" hidden>
+						<summary><?php esc_html_e( 'More details', 'twentyseventeen-westonson' ); ?></summary>
+						<iframe srcdoc=""></iframe>
+						<script>
+						function renderErrorDetails( data ) {
+							if ( data.bodyText.trim().length ) {
+								const details = document.getElementById( 'error-details' );
+								details.querySelector( 'iframe' ).srcdoc = data.bodyText;
+								details.hidden = false;
+							}
+						}
+						</script>
+						<?php wp_print_service_worker_error_details_script( 'renderErrorDetails' ); ?>
+					</details>
+				</div><!-- .page-content -->
+			</section><!-- .error-500 -->
+		</main><!-- #main -->
+	</div><!-- #primary -->
+</div><!-- .wrap -->
+
+<?php
+get_footer();

--- a/functions.php
+++ b/functions.php
@@ -134,22 +134,6 @@ add_action( 'customize_register', function( WP_Customize_Manager $wp_customize )
 	) );
 } );
 
-// Make it easier to test changes to the offline.php template by bumping the precache entry revision by the modified time.
-add_filter( 'wp_offline_error_precache_entry', function( $entry ) {
-	if ( WP_DEBUG && is_array( $entry ) ) {
-		$entry['revision'] .= '-' . filemtime( __DIR__ . '/offline.php' );
-	}
-	return $entry;
-} );
-
-// Make it easier to test changes to the 500.php template by bumping the precache entry revision by the modified time.
-add_filter( 'wp_server_error_precache_entry', function( $entry ) {
-	if ( WP_DEBUG && is_array( $entry ) ) {
-		$entry['revision'] .= '-' . filemtime( __DIR__ . '/500.php' );
-	}
-	return $entry;
-} );
-
 // Remove the has-sidebar class from the 500.php and offline.php templates since they do not have the sidebar.
 add_filter( 'body_class', function( $body_classes ) {
 	if ( ( function_exists( 'is_500' ) && is_500() ) || ( function_exists( 'is_offline' ) && is_offline() ) ) {

--- a/functions.php
+++ b/functions.php
@@ -162,3 +162,25 @@ add_action( 'wp_enqueue_scripts', function() {
 		wp_script_add_data( $handle, 'precache', true );
 	}
 }, PHP_INT_MAX );
+
+// Add offline template to list of templates in AMP.
+add_filter( 'amp_supportable_templates', function( $supportable_templates ) {
+	$supportable_templates['is_offline'] = array(
+		'label' => __( 'Offline', 'twentyseventeen-westonson' ),
+	);
+	return $supportable_templates;
+} );
+
+/*
+ * As alternative to precaching scripts for offline page, just use the AMP version instead.
+ * This has benefit of automatically excluding other scripts enqueued by plugins.
+ */
+if ( function_exists( 'is_amp_endpoint' ) ) {
+	add_filter( 'wp_offline_error_precache_entry', function( $entry ) {
+		$supportable_templates = AMP_Theme_Support::get_supportable_templates();
+		if ( ! amp_is_canonical() && ! empty( $supportable_templates['is_offline']['supported'] ) && is_array( $entry ) ) {
+			$entry['url'] = add_query_arg( amp_get_slug(), '', $entry['url'] );
+		}
+		return $entry;
+	} );
+}

--- a/functions.php
+++ b/functions.php
@@ -162,22 +162,3 @@ add_action( 'wp_enqueue_scripts', function() {
 		wp_script_add_data( $handle, 'precache', true );
 	}
 }, PHP_INT_MAX );
-
-// Add runtime caching of fonts. Use cache-first runtime caching for Google Fonts. Ported from <https://gist.github.com/sebastianbenz/1d449dee039202d8b7464f1131eae449>.
-add_action( 'wp_front_service_worker', function( WP_Service_Workers $service_workers ) {
-	$service_workers->register_cached_route(
-		'https://fonts.(?:googleapis|gstatic).com/(.*)',
-		WP_Service_Workers::STRATEGY_CACHE_FIRST,
-		array(
-			'cacheName' => 'twentyseventeen-fonts',
-			'plugins'   => array(
-				'cacheableResponse' => array(
-					'statuses' => array( 0, 200 ),
-				),
-				'expiration'        => array(
-					'maxEntries' => 30,
-				),
-			),
-		)
-	);
-} );

--- a/functions.php
+++ b/functions.php
@@ -165,9 +165,11 @@ add_action( 'wp_enqueue_scripts', function() {
 
 // Add offline template to list of templates in AMP.
 add_filter( 'amp_supportable_templates', function( $supportable_templates ) {
-	$supportable_templates['is_offline'] = array(
-		'label' => __( 'Offline', 'twentyseventeen-westonson' ),
-	);
+	if ( function_exists( 'is_offline' ) ) {
+		$supportable_templates['is_offline'] = array(
+			'label' => __( 'Offline', 'twentyseventeen-westonson' ),
+		);
+	}
 	return $supportable_templates;
 } );
 

--- a/functions.php
+++ b/functions.php
@@ -101,7 +101,7 @@ add_action( 'wp_enqueue_scripts', function() {
 		'twentyseventeen-parent-style',
 		trailingslashit( get_template_directory_uri() ) . 'style.css',
 		array(),
-		false
+		'1.1'
 	);
 	wp_styles()->registered['twentyseventeen-style']->deps[] = 'twentyseventeen-parent-style';
 }, 20 );

--- a/offline.php
+++ b/offline.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @link https://github.com/xwp/pwa-wp
+ *
+ * @package Twenty_Seventeen_Westonson
+ */
+
+// Prevent showing nav menus.
+add_filter( 'has_nav_menu', '__return_false' );
+
+// Remove other assets not available offline.
+remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+
+get_header(); ?>
+
+<div class="wrap">
+	<div id="primary" class="content-area">
+		<main id="main" class="site-main" role="main">
+
+			<section class="error-offline">
+				<header class="page-header">
+					<h1 class="page-title"><?php esc_html_e( 'Oops! It looks like you&#8217;re offline.', 'twentyseventeen-westonson' ); ?></h1>
+				</header><!-- .page-header -->
+
+				<div class="page-content">
+					<p><?php esc_html_e( 'Please check your internet connection, and try again.', 'twentyseventeen-westonson' ); ?></p>
+				</div><!-- .page-content -->
+			</section><!-- .error-offline -->
+		</main><!-- #main -->
+	</div><!-- #primary -->
+</div><!-- .wrap -->
+
+<?php
+get_footer();

--- a/offline.php
+++ b/offline.php
@@ -10,9 +10,6 @@
 // Prevent showing nav menus.
 add_filter( 'has_nav_menu', '__return_false' );
 
-// Remove other assets not available offline.
-remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
-
 get_header(); ?>
 
 <div class="wrap">

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ Theme Name: Twenty Seventeen Westonson
 Description: Weston's child (son) theme of Twenty Seventeen.
 Author: Weston Ruter, XWP
 Author URI: https://weston.ruter.net/
-Version: 1.0
+Version: 1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentyseventeen

--- a/style.css
+++ b/style.css
@@ -33,3 +33,12 @@ Use it to make something cool, have fun, and share what you've learned with othe
 		clear: none;
 	}
 }
+
+/* Style error details on the 500.php template */
+#error-details > iframe {
+	width: 100%;
+}
+#error-details > summary {
+	user-select: none;
+	cursor: pointer;
+}


### PR DESCRIPTION
See https://github.com/xwp/pwa-wp/pull/53

* Define `offline.php` and `500.php` templates to include the theme's header, footer, and styles.
  * Hide menus from being displayed on the offline template since if offline there is nowhere for the user to go.
  * Patch Twenty Seventeen to include offline and 500 templates among those which do not have sidebars so they are styled properly.
* Mark scripts and styles which should be precached by the PWA plugin.
* Serve the AMP version of the offline template when the user's connection is down.