### PR TITLE
Add amp-live-list commenting support

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -6,7 +6,6 @@
  * and the comment form.
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
- * @todo apply changes
  *
  * @package Twenty_Seventeen_Westonson
  */

--- a/comments.php
+++ b/comments.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * The template for displaying comments in AMP.
+ *
+ * This is the template that displays the area of the page that contains both the current comments
+ * and the comment form.
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ * @todo apply changes
+ *
+ * @package Twenty_Seventeen_Westonson
+ */
+
+$amp_theme_support = get_theme_support( 'amp' );
+
+$supports_comments_live_list = (
+	function_exists( 'is_amp_endpoint' )
+	&&
+	is_amp_endpoint()
+	&&
+	! empty( $amp_theme_support[0]['comments_live_list'] )
+);
+
+if ( ! $supports_comments_live_list ) {
+	require get_template_directory() . '/' . basename( __FILE__ );
+	return;
+}
+
+/*
+ * If the current post is protected by a password and
+ * the visitor has not yet entered the password we will
+ * return early without loading the comments.
+ */
+if ( post_password_required() ) {
+	return;
+}
+
+// @todo When there are no comments, the amp-live-list should be populated with something to indicate that that there are no comments yet.
+// @todo When the first comment is posted, the CSS will be broken because it will have been tree-shaken. We should prevent tree-shaking for any comment CSS when on a post that has commenting enabled.
+?>
+
+<div id="comments" class="comments-area">
+
+	<h2 class="comments-title">
+		<?php esc_html_e( 'Comments', 'twentyseventeen-westonson' ); ?>
+	</h2>
+
+	<amp-live-list id="amp-live-comments-list-<?php the_ID(); ?>" data-max-items-per-page="10000"
+		<?php
+		if ( 'desc' !== get_option( 'comment_order' ) ) {
+			echo 'sort="ascending"';
+		};
+		?>
+	>
+		<ol items class="comment-list">
+			<?php
+			wp_list_comments( array(
+				'avatar_size' => 100,
+				'style'       => 'ol',
+				'short_ping'  => true,
+				'reply_text'  => twentyseventeen_get_svg( array( 'icon' => 'mail-reply' ) ) . __( 'Reply', 'twentyseventeen' ),
+			) );
+			?>
+		</ol>
+		<div update class="live-list__button">
+			<button class="button" on="tap:amp-live-comments-list-<?php the_ID(); ?>.update">
+				<?php esc_html_e( 'New comment(s)', 'ampconf' ); ?>
+			</button>
+		</div>
+		<nav pagination>
+			<?php
+			the_comments_pagination( array(
+				'prev_text' => twentyseventeen_get_svg( array( 'icon' => 'arrow-left' ) ) . '<span class="screen-reader-text">' . __( 'Previous', 'twentyseventeen' ) . '</span>',
+				'next_text' => '<span class="screen-reader-text">' . __( 'Next', 'twentyseventeen' ) . '</span>' . twentyseventeen_get_svg( array( 'icon' => 'arrow-right' ) ),
+			) );
+			?>
+		</nav>
+	</amp-live-list>
+
+	<?php if ( ! comments_open() && get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) : ?>
+		<p class="no-comments"><?php _e( 'Comments are closed.', 'twentyseventeen' ); ?></p>
+	<?php endif; ?>
+
+	<?php comment_form(); ?>
+
+</div><!-- #comments -->

--- a/functions.php
+++ b/functions.php
@@ -5,11 +5,40 @@
  * @package Twenty_Seventeen_Westonson
  */
 
-add_theme_support( 'amp', array(
-	'paired' => false, // Needed in order to support service_worker_streaming.
-) );
+/*
+ * To enable service worker streaming, do:
+ *
+ *     wp theme mod set service_worker_navigation streaming
+ *
+ * To enable comments live list, do:
+ *
+ *     wp theme mod set amp_comments_live_list true
+ */
+add_action( 'after_setup_theme', function() {
 
-add_theme_support( 'service_worker_streaming' );
+	$amp_native_mode        = get_theme_mod( 'amp_native_mode', false );
+	$amp_comments_live_list = rest_sanitize_boolean( get_theme_mod( 'amp_comments_live_list', false ) );
+	$has_streaming          = 'streaming' === get_theme_mod( 'service_worker_navigation' );
+
+	$support_args = array(
+		'paired' => ! (
+			$amp_native_mode
+			||
+			$has_streaming
+		),
+	);
+
+	if ( $amp_comments_live_list ) {
+		$support_args['comments_live_list'] = true;
+	}
+
+	if ( $has_streaming ) {
+		add_theme_support( 'service_worker_streaming' );
+	}
+
+	add_theme_support( 'amp', $support_args );
+} );
+
 
 // Make sure the precached streaming header varies by the header logo and header image.
 add_filter( 'wp_streaming_header_precache_entry', function( $entry ) {

--- a/functions.php
+++ b/functions.php
@@ -6,11 +6,11 @@
  */
 
 /*
- * To enable service worker streaming, do:
+ * To enable service worker streaming, use WP-CLI as follows:
  *
  *     wp theme mod set service_worker_navigation streaming
  *
- * To enable comments live list, do:
+ * To enable AMP comments live list <https://github.com/Automattic/amp-wp/wiki/Commenting#live-commenting-using-a-live-list>, do:
  *
  *     wp theme mod set amp_comments_live_list true
  */

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,12 @@
  */
 
 /*
- * To enable service worker streaming, use WP-CLI as follows:
+ * To change between Native and Paired modes for AMP, use WP-CLI to do:
+ *
+ *     wp theme mod set amp_mode paired
+ *     wp theme mod set amp_mode native
+ *
+ * To enable service worker streaming (which also forces native mode), use WP-CLI as follows:
  *
  *     wp theme mod set service_worker_navigation streaming
  *
@@ -16,13 +21,13 @@
  */
 add_action( 'after_setup_theme', function() {
 
-	$amp_native_mode        = get_theme_mod( 'amp_native_mode', false );
+	$amp_mode               = get_theme_mod( 'amp_mode', 'paired' );
 	$amp_comments_live_list = rest_sanitize_boolean( get_theme_mod( 'amp_comments_live_list', false ) );
 	$has_streaming          = 'streaming' === get_theme_mod( 'service_worker_navigation' );
 
 	$support_args = array(
 		'paired' => ! (
-			$amp_native_mode
+			'native' === $amp_mode
 			||
 			$has_streaming
 		),

--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -7,7 +7,7 @@
 
 require get_template_directory() . '/template-parts/header/site-branding.php';
 
-if ( ! class_exists( 'WP_Service_Worker_Navigation_Routing_Component' ) ) {
+if ( ! class_exists( 'WP_Service_Worker_Navigation_Routing_Component' ) || ! current_theme_supports( 'service_worker_streaming' ) ) {
 	return;
 }
 


### PR DESCRIPTION
To use, activate the AMP plugin and switch to the paired or native modes. Then with WP-CLI do:

```bash
wp theme mod set amp_comments_live_list true
```

Then when accessing a post with commenting, new comments will be submitted using XHR and new comments will appear without reloading the page.

# Todo

- [ ] Add styling for the `amp-live-list` Update button.
- [ ] When there are no comments, the amp-live-list should be populated with something to indicate that that there are no comments yet.
- [ ] When the first comment is posted, the CSS will be broken because it will have been tree-shaken. We should prevent tree-shaking for any comment CSS when on a post that has commenting enabled.

