### PR TITLE
Prevent HTML5 novalidate attribute from being added to commentform in AMP

### DIFF
--- a/class-comment-form-yesvalidate-sanitizer.php
+++ b/class-comment-form-yesvalidate-sanitizer.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Class Comment_Form_YesValidate_Sanitizer.
+ *
+ * @package Twenty_Seventeen_Westonson
+ */
+
+namespace Twenty_Seventeen_Westonson;
+
+/**
+ * Class Comment_Form_YesValidate_Sanitizer
+ *
+ * Ensures that the novalidate attribute is removed from the comment form because client-side validation needs to be
+ */
+class Comment_Form_YesValidate_Sanitizer extends \AMP_Base_Sanitizer {
+
+	/**
+	 * Remove the novalidate attribute is removed from the comment form.
+	 *
+	 * This needs to be made part of the plugin.
+	 */
+	public function sanitize() {
+		/**
+		 * Comment form.
+		 *
+		 * @var \DOMElement $form
+		 */
+		$form = $this->dom->getElementById( 'commentform' );
+		if ( $form ) {
+			$form->removeAttribute( 'novalidate' );
+		}
+	}
+}

--- a/functions.php
+++ b/functions.php
@@ -44,6 +44,11 @@ add_action( 'after_setup_theme', function() {
 	add_theme_support( 'amp', $support_args );
 } );
 
+add_filter( 'amp_content_sanitizers', function( $sanitizers ) {
+	require_once __DIR__ . '/class-comment-form-yesvalidate-sanitizer.php';
+	$sanitizers['Twenty_Seventeen_Westonson\Comment_Form_YesValidate_Sanitizer'] = array();
+	return $sanitizers;
+} );
 
 // Make sure the precached streaming header varies by the header logo and header image.
 add_filter( 'wp_streaming_header_precache_entry', function( $entry ) {


### PR DESCRIPTION
Unfortunately WordPress forces the `novalidate` attribute to be present on forms when the theme supports HTML5:

https://github.com/WordPress/wordpress-develop/blob/5d92e0c0a950399c53294a41000305ddcf47efb5/src/wp-includes/comment-template.php#L2383

But in AMP we really need the browser to be doing the client-side validation, especially in the case of when the user is offline because in that case the service worker will queue an _invalid_ comment to replay, which will then get rejected by the server. So we need to make sure we do client-side validation to help ensure that a valid request will be queued for background sync.

This needs to be worked into the `AMP_Comments_Sanitizer` in the AMP plugin itself.