### PR TITLE
Add AMP service worker integration

### DIFF
--- a/class-comment-form-yesvalidate-sanitizer.php
+++ b/class-comment-form-yesvalidate-sanitizer.php
@@ -10,7 +10,11 @@ namespace Twenty_Seventeen_Westonson;
 /**
  * Class Comment_Form_YesValidate_Sanitizer
  *
- * Ensures that the novalidate attribute is removed from the comment form because client-side validation needs to be
+ * Remove novalidate attribute from comment form to force client-side form validation to prevent relying on server-side
+ * validation which will not be available during offline commenting. This ensures that background sync wont POST a
+ * comment that we already know to be invalid.
+ *
+ * @todo Core should allow for this to be omitted removed.
  */
 class Comment_Form_YesValidate_Sanitizer extends \AMP_Base_Sanitizer {
 

--- a/functions.php
+++ b/functions.php
@@ -60,10 +60,15 @@ add_action(
 		}
 
 		$support_args = array(
-			'paired' => ! (
+			'paired'         => ! (
 				'native' === $amp_mode
 				||
 				$has_streaming
+			),
+			'service_worker' => array(
+				'cdn_script_caching'   => true,
+				'google_fonts_caching' => true,
+				'image_caching'        => true,
 			),
 		);
 

--- a/functions.php
+++ b/functions.php
@@ -48,11 +48,6 @@ add_action(
 		$amp_comments_live_list = rest_sanitize_boolean( get_theme_mod( 'amp_comments_live_list', false ) );
 		$has_streaming          = 'streaming' === get_theme_mod( 'service_worker_navigation' );
 
-		// Abort if classic mode.
-		if ( 'classic' === $amp_mode ) {
-			return;
-		}
-
 		$support_args = array(
 			'paired' => true,
 		);

--- a/functions.php
+++ b/functions.php
@@ -89,6 +89,15 @@ add_filter(
 	}
 );
 
+// Ideally core would support this instead of requiring a hack like the above, as it would work in AMP and not-AMP alike.
+add_filter(
+	'comment_form_defaults',
+	function ( $defaults ) {
+		$defaults['novalidate_form'] = false;
+		return $defaults;
+	}
+);
+
 // Make sure the precached streaming header varies by the header logo and header image.
 add_filter(
 	'wp_streaming_header_precache_entry',

--- a/functions.php
+++ b/functions.php
@@ -33,11 +33,6 @@ add_filter(
 );
 
 /*
- * To change between Native and Paired modes for AMP, use WP-CLI to do:
- *
- *     wp theme mod set amp_mode paired
- *     wp theme mod set amp_mode native
- *
  * To enable service worker streaming (which also forces native mode), use WP-CLI as follows:
  *
  *     wp theme mod set service_worker_navigation streaming
@@ -50,7 +45,6 @@ add_action(
 	'after_setup_theme',
 	function() {
 
-		$amp_mode               = get_theme_mod( 'amp_mode', 'paired' );
 		$amp_comments_live_list = rest_sanitize_boolean( get_theme_mod( 'amp_comments_live_list', false ) );
 		$has_streaming          = 'streaming' === get_theme_mod( 'service_worker_navigation' );
 
@@ -60,16 +54,13 @@ add_action(
 		}
 
 		$support_args = array(
-			'paired'         => ! (
-				'native' === $amp_mode
-				||
-				$has_streaming
-			),
-			'service_worker' => array(
-				'cdn_script_caching'   => true,
-				'google_fonts_caching' => true,
-				'image_caching'        => true,
-			),
+			'paired' => true,
+		);
+
+		$support_args['service_worker'] = array(
+			'cdn_script_caching'   => true,
+			'google_fonts_caching' => true,
+			'image_caching'        => true,
 		);
 
 		if ( $amp_comments_live_list ) {

--- a/functions.php
+++ b/functions.php
@@ -75,6 +75,11 @@ add_action(
 	}
 );
 
+/*
+ * Remove novalidate attribute from comment form to force client-side form validation to prevent relying on server-side
+ * validation which will not be available during offline commenting. This ensures that background sync wont POST a
+ * comment that we already know to be invalid.
+ */
 add_filter(
 	'amp_content_sanitizers',
 	function( $sanitizers ) {


### PR DESCRIPTION
Pairs well with a plugin that enables network-first navigation request caching strategy:

```php
<?php
/**
 * Plugin Name: Network-First Navigation Request Caching Strategy
 * Author: Weston Ruter
 */

add_filter(
	'wp_service_worker_navigation_caching_strategy',
	function() {
		return WP_Service_Worker_Caching_Routes::STRATEGY_NETWORK_FIRST;
	}
);

add_filter(
	'wp_service_worker_navigation_caching_strategy_args',
	function( $args ) {
		$args['cacheName']                           = 'pages';
		$args['plugins']['expiration']['maxEntries'] = 50;
		return $args;
	}
);
```